### PR TITLE
Update ExceptionHandler.php

### DIFF
--- a/libraries/src/Exception/ExceptionHandler.php
+++ b/libraries/src/Exception/ExceptionHandler.php
@@ -41,7 +41,7 @@ class ExceptionHandler
 		{
 			try
 			{
-				Log::add($errorMessage, Log::WARNING, 'deprecated');
+				Log::add("$errorMessage - $errorFile - Line $errorLine", Log::WARNING, 'deprecated');
 			}
 			catch (\Exception $e)
 			{


### PR DESCRIPTION
Pull Request for Issue #38137 .

### Summary of Changes

Add file and line reference to deprecation exception messages.

### Testing Instructions
Enable deprecated method calls logging (Admin panel -> global configuration -> logging)
Run just about any view in the back end.
View file <root>/administrator/logs/deprecated.php to see reports of deprecated calls.


### Actual result BEFORE applying this Pull Request
Deprecation messages appear (dozens of them) without any reference to location of the piece code causing the exception.


### Expected result AFTER applying this Pull Request
Deprecation messages contain a full file name and line number locating the cause of the exception.


### Documentation Changes Required
None
